### PR TITLE
BZ-2927: fix: render WebView on key window instead of view controller's view

### DIFF
--- a/BlazeSDK/Classes/BlazeWebView.swift
+++ b/BlazeSDK/Classes/BlazeWebView.swift
@@ -28,6 +28,7 @@ class BlazeWebView: NSObject, WKScriptMessageHandler {
 
         self.webView = WKWebView(frame: .zero, configuration: config)
         self.webView.navigationDelegate = self
+        self.webView.scrollView.contentInsetAdjustmentBehavior = .never
 
         if let url = URL(string: getBaseUrl(payload: initiatePayload)) {
             self.webView.load(URLRequest(url: url))
@@ -115,14 +116,16 @@ class BlazeWebView: NSObject, WKScriptMessageHandler {
 
     private func renderView() {
         DispatchQueue.main.async {
-            self.webView.frame = self.context.view.bounds
-            self.context.view.addSubview(self.webView)
+            guard let window = self.context.view.window else { return }
+            self.webView.frame = window.bounds
+            window.addSubview(self.webView)
         }
     }
 
     private func hideView() {
         DispatchQueue.main.async {
             self.webView.removeFromSuperview()
+            self.webView.frame = .zero
         }
     }
 


### PR DESCRIPTION
… on iOS

Previously, the WebView was added as a subview of the Flutter view controller's view, whose bounds did not cover the full screen. This caused the Offers bottom sheet to render incorrectly  content was clipped and the overlay appeared misaligned on all iOS devices.

Fix: attach the WebView directly to the key window instead of the view controller's view, ensuring full-screen coverage regardless of safe area insets, navigation bars, or parent view constraints. Also reset the WebView frame to .zero on hide to avoid stale geometry.